### PR TITLE
Use cached data when activities missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,8 +313,13 @@ if page == "🏠 Tableau général":
 if df_activities is not None and not df_activities.empty:
     df = df_activities.copy()
 else:
-    st.warning("⚠️ Les données Strava ne sont pas encore chargées.")
-    df = pd.DataFrame()
+    df_cache = charger_cache_parquet()
+    if not df_cache.empty:
+        df = df_cache.copy()
+        st.info("✅ Données chargées depuis le cache.")
+    else:
+        st.warning("⚠️ Les données Strava ne sont pas encore chargées.")
+        df = pd.DataFrame()
 
 df_cache = charger_cache_parquet()
 if 'id' not in df_cache.columns:


### PR DESCRIPTION
## Summary
- load activities from saved cache if session data isn't available

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6841904bcd648322afb837773ee3c0f1